### PR TITLE
Basic認証実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,14 @@
 class ApplicationController < ActionController::Base
+  before_action :basic_auth
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   private
+  def basic_auth
+    authenticate_or_request_with_http_basic do |username, password|
+      username == 'mile' && password == '8119'
+    end
+  end
+
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:nick_name])
   end


### PR DESCRIPTION
WHAT#
Basic認証を実装

WHY#
サーバーとの通信が可能なユーザーとパスワードをあらかじめ設定しておき、それに一致したユーザーのみが、Webアプリケーションを利用できるようにするため。